### PR TITLE
Inject experiment id into RedisTraceRecorder.

### DIFF
--- a/galileodb/recorder/recorder.py
+++ b/galileodb/recorder/recorder.py
@@ -13,7 +13,7 @@ class Recorder:
 
         self.telemetry_recorder = ExperimentTelemetryRecorder(rds, exp_db, experiment_id)
         self.event_recorder = ExperimentEventRecorderThread(ExperimentEventRecorder(rds, exp_db, experiment_id))
-        self.trace_recorder = RedisTraceRecorder(rds, DatabaseTraceWriter(exp_db))
+        self.trace_recorder = RedisTraceRecorder(rds, experiment_id, DatabaseTraceWriter(exp_db))
 
     def start(self):
         self.telemetry_recorder.start()

--- a/galileodb/recorder/traces.py
+++ b/galileodb/recorder/traces.py
@@ -46,8 +46,9 @@ class TraceRecorder(threading.Thread, ABC):
 
 class RedisTraceRecorder(TraceRecorder):
 
-    def __init__(self, rds, writer: TraceWriter, flush_every=36) -> None:
+    def __init__(self, rds, exp_id: str, writer: TraceWriter, flush_every=36) -> None:
         super().__init__(rds)
+        self.exp_id = exp_id
         self.writer = writer
         self.buffer = list()
 
@@ -56,13 +57,14 @@ class RedisTraceRecorder(TraceRecorder):
 
     def run(self):
         try:
-            logger.debug('starting RedisTraceRecorder')
+            logger.debug('starting RedisTraceRecorder for experiment %s', self.exp_id)
             super().run()
         finally:
-            logger.debug('closing RedisTraceRecorder')
+            logger.debug('closing RedisTraceRecorder for experiment %s', self.exp_id)
             self._flush()
 
     def _record(self, t: RequestTrace):
+        t = t._replace(exp_id=self.exp_id)
         self.buffer.append(t)
 
         self.i = (self.i + 1) % self.flush_every

--- a/tests/recorder/test_traces.py
+++ b/tests/recorder/test_traces.py
@@ -1,9 +1,11 @@
 import unittest
 from queue import Queue
+from typing import List
 
 from galileodb.model import RequestTrace
-from galileodb.recorder.traces import TraceRecorder, TracesSubscriber
+from galileodb.recorder.traces import TraceRecorder, TracesSubscriber, RedisTraceRecorder
 from galileodb.reporter.traces import RedisTraceReporter
+from galileodb.trace import TraceWriter
 from tests.testutils import RedisResource
 
 
@@ -58,3 +60,46 @@ class TraceSubscriberTest(unittest.TestCase):
         actual = parse(r"r1,c1,s1,1.1000000,1.2000000,1.3000000,200,None,None,foo=bar\nfield1=value1,a,b,c")
 
         self.assertEqual(expected, actual)
+
+
+class RedisTraceRecorderTest(unittest.TestCase):
+    redis = RedisResource()
+
+    def setUp(self) -> None:
+        self.redis.setUp()
+
+    def tearDown(self) -> None:
+        self.redis.tearDown()
+
+    def test_recorder(self):
+        queue = Queue()
+
+        class TestTraceWriter(TraceWriter):
+            def write(self, traces: List[RequestTrace]):
+                for t in traces:
+                    queue.put(t)
+
+        recorder = RedisTraceRecorder(self.redis.rds, exp_id='exp1', writer=TestTraceWriter(), flush_every=2)
+        recorder.start()
+
+        reporter = RedisTraceReporter(self.redis.rds)
+
+        fixture = [
+            RequestTrace('r1', 'c1', 's1', 1.1, 1.2, 1.3, 200, response='hello there'),
+            RequestTrace('r1', 'c1', 's1', 1.1, 1.2, 1.3, 200, server='s1'),
+        ]
+
+        expected = [
+            RequestTrace('r1', 'c1', 's1', 1.1, 1.2, 1.3, 200, response='hello there', exp_id='exp1'),
+            RequestTrace('r1', 'c1', 's1', 1.1, 1.2, 1.3, 200, server='s1', exp_id='exp1')
+        ]
+
+        reporter.report_multiple(fixture)
+
+        trace = queue.get(timeout=2)
+        self.assertEqual(expected[0], trace)
+
+        trace = queue.get(timeout=2)
+        self.assertEqual(expected[1], trace)
+
+        recorder.stop(timeout=2)


### PR DESCRIPTION
Fixes bug, where not all traces have their exp_id assigned after stopping experiment.

Refs: #8